### PR TITLE
Ocultar chaves restantes na fase 2 ao clicar na chave correta

### DIFF
--- a/src/components/Phase2.jsx
+++ b/src/components/Phase2.jsx
@@ -83,7 +83,8 @@ const Phase2 = () => {
 
 
             if (key.id === correctKeyId) {
-
+                keys.style.display = 'none'
+                
                 fadeOutVolume(playback, 2000, () => {
                     setTimeout(() => {
                         playback.src = 'The-Resurrection-Stone.mp3';


### PR DESCRIPTION
**Descrição:**
Este Pull Request implementa uma melhoria na fase 2 do jogo, onde as chaves restantes são ocultadas quando o usuário clica na chave correta.

**Alterações:**
Funcionalidade: Agora, ao clicar na chave correta na fase 2, todas as outras chaves são ocultadas.
Código: A lógica de ocultação foi adicionada ao arquivo Phase2.jsx .
Testes: Foram realizados testes manuais para garantir que as chaves são ocultadas corretamente após clicar na chave correta.

**Motivo:**
Esta melhoria visa melhorar a experiência do usuário, tornando o jogo mais intuitivo e reduzindo a confusão visual após a escolha da chave correta, e apresentação do timer.

**Testes Realizados:**
Clicar em uma chave correta oculta todas as outras chaves.
Clicar em uma chave incorreta não altera a visibilidade das outras chaves.
A transição de fases funciona conforme esperado após a ocultação das chaves.
